### PR TITLE
Many fixes and improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,10 +40,10 @@ Request `gpu` resource in the designated queue.
 
     qsub -q gpu.q -l gpu=1 gpujob.sh
 
-The job script can access `SGE_GPU` variable.
+The job script can access `CUDA_VISIBLE_DEVICES` variable.
 
     #!/bin/sh
-    echo $SGE_GPU
+    echo $CUDA_VISIBLE_DEVICES
 
 The variable contains a comma-delimited device IDs, such as `0` or `0,1,2`
 depending on the number of `gpu` resources to be requested. Use the device ID

--- a/epilog.sh
+++ b/epilog.sh
@@ -8,7 +8,7 @@
 ENV_FILE=$SGE_JOB_SPOOL_DIR/environment
 if [ ! -f $ENV_FILE -o ! -r $ENV_FILE ]
 then
-  exit 1
+  exit 100
 fi
 
 # Remove lock files.

--- a/epilog.sh
+++ b/epilog.sh
@@ -12,9 +12,9 @@ then
 fi
 
 # Remove lock files.
-device_ids=$(grep SGE_GPU $ENV_FILE | \
+device_ids=$(grep CUDA_VISIBLE_DEVICES $ENV_FILE | \
              sed -e "s/,/ /g" | \
-             sed -n "s/SGE_GPU=\(.*\)/\1/p" | \
+             sed -n "s/CUDA_VISIBLE_DEVICES=\(.*\)/\1/p" | \
              xargs shuf -e)
 for device_id in $device_ids
 do

--- a/prolog.sh
+++ b/prolog.sh
@@ -5,6 +5,9 @@
 # Kota Yamaguchi 2015 <kyamagu@vision.is.tohoku.ac.jp>
 
 # Query how many gpus to allocate.
+
+source $SGE_ROOT/$SGE_CELL/common/settings.sh
+
 NGPUS=$(qstat -j $JOB_ID | \
         sed -n "s/hard resource_list:.*gpu=\([[:digit:]]\+\).*/\1/p")
 if [ -z $NGPUS ]

--- a/prolog.sh
+++ b/prolog.sh
@@ -49,5 +49,5 @@ then
 fi
 
 # Set the environment.
-echo SGE_GPU="$(echo $SGE_GPU | sed -e 's/^ //' | sed -e 's/ /,/g')" >> $ENV_FILE
+echo CUDA_VISIBLE_DEVICES="$(echo $SGE_GPU | sed -e 's/^ //' | sed -e 's/ /,/g')" >> $ENV_FILE
 exit 0

--- a/prolog.sh
+++ b/prolog.sh
@@ -48,6 +48,9 @@ done
 if [ $i -lt $NGPUS ]
 then
   echo "ERROR: Only reserved $i of $NGPUS requested devices."
+  for device_id in $SGE_GPU; do
+    rmdir /tmp/lock-gpu$device_id
+  done
   exit 100
 fi
 

--- a/prolog.sh
+++ b/prolog.sh
@@ -24,7 +24,7 @@ NGPUS=$(expr $NGPUS \* ${NSLOTS=1})
 ENV_FILE=$SGE_JOB_SPOOL_DIR/environment
 if [ ! -f $ENV_FILE -o ! -w $ENV_FILE ]
 then
-  exit 1
+  exit 100
 fi
 
 # Allocate and lock GPUs.
@@ -48,7 +48,7 @@ done
 if [ $i -lt $NGPUS ]
 then
   echo "ERROR: Only reserved $i of $NGPUS requested devices."
-  exit 1
+  exit 100
 fi
 
 # Set the environment.


### PR DESCRIPTION
1. set `CUDA_VISIBLE_DEVICES` in environment instead of `SGE_ROOT`
This variable is popularly used in tensorflow and pytorch.
1. <s>use file lock instead of directory lock
It seems that SGE is using directory lock.
But I think file lock is more popular in linux systems.</s>
1. source settings.sh in prolog
Inspired by https://github.com/kageback/sge-gpuprolog/commit/e615f58519471cfc802a3e13e846cad550b22c83
1. fix exit codes
See http://www.softpanorama.org/HPC/Grid_engine/prolog_and_epilog_scripts.shtml
1. removed lock file when failed
From #2 